### PR TITLE
Simplify weak reference list and fix initializers

### DIFF
--- a/Sources/NSRemoteShell/NSRemoteChannel.m
+++ b/Sources/NSRemoteShell/NSRemoteChannel.m
@@ -32,10 +32,10 @@
 {
     self = [super init];
     if (self) {
-        self.representedSession = representedSession;
-        self.representedChannel = representedChannel;
-        self.channelCompleted = NO;
-        self.currentTerminalSize = CGSizeMake(0, 0);
+        _representedSession = representedSession;
+        _representedChannel = representedChannel;
+        _channelCompleted = NO;
+        _currentTerminalSize = CGSizeMake(0, 0);
     }
     return self;
 }
@@ -94,7 +94,7 @@
     if (terminalSize) {
         self.requestTerminalSizeBlock = terminalSize;
     } else {
-        self.requestDataBlock = NULL;
+        self.requestTerminalSizeBlock = NULL;
     }
 }
 

--- a/Sources/NSRemoteShell/NSRemoteShell.h
+++ b/Sources/NSRemoteShell/NSRemoteShell.h
@@ -15,9 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, getter=isConnected) BOOL connected;
 @property (nonatomic, readonly, getter=isAuthenicated) BOOL authenticated;
 
-@property (nonatomic, readonly, nonnull, strong) NSString *remoteHost;
-@property (nonatomic, readonly, nonnull, strong) NSNumber *remotePort;
-@property (nonatomic, readonly, nonnull, strong) NSNumber *operationTimeout;
+@property (nonatomic, readonly, strong) NSString *remoteHost;
+@property (nonatomic, readonly, strong) NSNumber *remotePort;
+@property (nonatomic, readonly, strong) NSNumber *operationTimeout;
 
 @property (nonatomic, readonly, nullable, strong) NSString *resolvedRemoteIpAddress;
 @property (nonatomic, readonly, nullable, strong) NSString *remoteBanner;
@@ -26,9 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark initializer
 
 - (instancetype)init;
-- (instancetype)setupConnectionHost:(nonnull NSString *)targetHost;
-- (instancetype)setupConnectionPort:(nonnull NSNumber *)targetPort;
-- (instancetype)setupConnectionTimeout:(nonnull NSNumber *)timeout;
+- (instancetype)setupConnectionHost:(NSString *)targetHost;
+- (instancetype)setupConnectionPort:(NSNumber *)targetPort;
+- (instancetype)setupConnectionTimeout:(NSNumber *)timeout;
 
 #pragma mark event loop
 
@@ -42,12 +42,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark authenticate
 
-- (instancetype)authenticateWith:(nonnull NSString *)username
-                     andPassword:(nonnull NSString *)password;
 - (instancetype)authenticateWith:(NSString *)username
-                            andPublicKey:(nullable NSString *)publicKey
-                            andPrivateKey:(NSString *)privateKey
-                             andPassword:(nullable NSString *)password;
+                     andPassword:(NSString *)password;
+- (instancetype)authenticateWith:(NSString *)username
+                    andPublicKey:(nullable NSString *)publicKey
+                   andPrivateKey:(NSString *)privateKey
+                     andPassword:(nullable NSString *)password;
 
 #pragma mark execution
 
@@ -57,10 +57,10 @@ NS_ASSUME_NONNULL_BEGIN
      withContinuationHandler:(nullable BOOL (^)(void))continuationBlock;
 
 - (instancetype)openShellWithTerminal:(nullable NSString*)terminalType
-                    withTermianlSize:(nullable CGSize (^)(void))requestTermianlSize
-                       withWriteData:(nullable NSString* (^)(void))requestWriteData
-                          withOutput:(void (^)(NSString * _Nonnull))responseDataBlock
-             withContinuationHandler:(BOOL (^)(void))continuationBlock;
+                     withTerminalSize:(nullable CGSize (^)(void))requestTerminalSize
+                        withWriteData:(nullable NSString* (^)(void))requestWriteData
+                           withOutput:(void (^)(NSString * _Nonnull))responseDataBlock
+              withContinuationHandler:(BOOL (^)(void))continuationBlock;
 
 @end
 

--- a/Sources/NSRemoteShell/NSRemoteShell.m
+++ b/Sources/NSRemoteShell/NSRemoteShell.m
@@ -42,18 +42,21 @@
 
 - (instancetype)init {
     self = [super init];
-    self.remoteHost = @"";
-    self.remotePort = @(22);
-    self.operationTimeout = @(8);
-    self.connected = NO;
-    self.authenticated = NO;
-    self.resolvedRemoteIpAddress = NULL;
-    
-    self.associatedSocket = NULL;
-    self.associatedSession = NULL;
-    self.associatedChannel = [[NSMutableArray alloc] init];
-    
-    self.requestInvokations = [[NSMutableArray alloc] init];
+
+    if (self) {
+        _remoteHost = @"";
+        _remotePort = @(22);
+        _operationTimeout = @(8);
+        _connected = NO;
+        _authenticated = NO;
+        _resolvedRemoteIpAddress = NULL;
+
+        _associatedSocket = NULL;
+        _associatedSession = NULL;
+        _associatedChannel = [[NSMutableArray alloc] init];
+
+        _requestInvokations = [[NSMutableArray alloc] init];
+    }
     
     [[TSEventLoop sharedLoop] delegatingRemoteWith:self];
     
@@ -200,17 +203,17 @@
 }
 
 - (instancetype)openShellWithTerminal:(nullable NSString*)terminalType
-                    withTermianlSize:(nullable CGSize (^)(void))requestTermianlSize
-                       withWriteData:(nullable NSString* (^)(void))requestWriteData
-                          withOutput:(void (^)(NSString * _Nonnull))responseDataBlock
-             withContinuationHandler:(BOOL (^)(void))continuationBlock
+                     withTerminalSize:(nullable CGSize (^)(void))requestTerminalSize
+                        withWriteData:(nullable NSString* (^)(void))requestWriteData
+                           withOutput:(void (^)(NSString * _Nonnull))responseDataBlock
+              withContinuationHandler:(BOOL (^)(void))continuationBlock
 {
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
     __weak typeof(self) magic = self;
     @synchronized (self.requestInvokations) {
         id block = [^{
             [magic uncheckedConcurrencyOpenShellWithTerminal:terminalType
-                                            withTermianlSize:requestTermianlSize
+                                            withTerminalSize:requestTerminalSize
                                                withWriteData:requestWriteData
                                                   withOutput:responseDataBlock
                                      withContinuationHandler:continuationBlock
@@ -543,11 +546,11 @@
 }
 
 - (void)uncheckedConcurrencyOpenShellWithTerminal:(nullable NSString*)terminalType
-                                withTermianlSize:(nullable CGSize (^)(void))requestTermianlSize
-                                   withWriteData:(nullable NSString* (^)(void))requestWriteData
-                                      withOutput:(void (^)(NSString * _Nonnull))responseDataBlock
-                         withContinuationHandler:(BOOL (^)(void))continuationBlock
-                         withCompletionSemaphore:(dispatch_semaphore_t)completionSemaphore
+                                 withTerminalSize:(nullable CGSize (^)(void))requestTerminalSize
+                                    withWriteData:(nullable NSString* (^)(void))requestWriteData
+                                       withOutput:(void (^)(NSString * _Nonnull))responseDataBlock
+                          withContinuationHandler:(BOOL (^)(void))continuationBlock
+                          withCompletionSemaphore:(dispatch_semaphore_t)completionSemaphore
 {
     if (![self uncheckedConcurrencyValidateSession]) {
         [self uncheckedConcurrencyDisconnect];
@@ -579,7 +582,7 @@
     }
     NSRemoteChannel *channelObject = [[NSRemoteChannel alloc] initWithRepresentedSession:session
                                                                    withRepresentedChanel:channel];
-    if (requestTermianlSize) { [channelObject setTerminalSizeChain:requestTermianlSize]; }
+    if (requestTerminalSize) { [channelObject setTerminalSizeChain:requestTerminalSize]; }
     if (requestWriteData) { [channelObject setRequestDataChain:requestWriteData]; }
     if (responseDataBlock) { [channelObject setRecivedDataChain:responseDataBlock]; }
     if (continuationBlock) { [channelObject setContinuationChain:continuationBlock]; }

--- a/Sources/NSRemoteShell/TSEventLoop.h
+++ b/Sources/NSRemoteShell/TSEventLoop.h
@@ -12,17 +12,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSRemoteShellWeakReference : NSObject
-
-@property (nonatomic, readwrite, weak) NSRemoteShell* representedObject;
-
-- (instancetype)initWith:(NSRemoteShell*)remoteObject;
-
-@end
-
 @interface TSEventLoop : NSObject <NSPortDelegate>
 
-+(id)sharedLoop;
++ (instancetype)sharedLoop;
 
 - (void)explicitRequestHandle;
 - (void)delegatingRemoteWith:(NSRemoteShell*)object;


### PR DESCRIPTION
- Use `NSHashTable.weakObjects` to store weak references
- Assign ivars to avoid calling setter during initialization
- Typo fix